### PR TITLE
Bugfix-endMeeting

### DIFF
--- a/app/src/main/java/com/group7/meetr/activity/ModeratorActivity.java
+++ b/app/src/main/java/com/group7/meetr/activity/ModeratorActivity.java
@@ -14,7 +14,6 @@ import androidx.databinding.DataBindingUtil;
 
 import com.group7.meetr.R;
 import com.group7.meetr.data.model.Meeting;
-import com.group7.meetr.data.remote.SessionHandler;
 import com.group7.meetr.databinding.ActivityModeratorBinding;
 import com.group7.meetr.viewmodel.ModeratorViewModel;
 
@@ -61,24 +60,18 @@ public class ModeratorActivity extends AppCompatActivity {
         });
     }
     private void goToEndMeetingPrompt(Button btn) {
-        DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                switch (which){
-                    case DialogInterface.BUTTON_POSITIVE:
-                        Toast t = new Toast(ModeratorActivity.this);
-                        t.setText("Ending meeting did not succeed!");
-                        SessionHandler.callEndMeeting(Meeting.getMeetingID(),t);
+        DialogInterface.OnClickListener dialogClickListener = (dialog, which) -> {
+            switch (which){
+                case DialogInterface.BUTTON_POSITIVE:
+                    Toast t = new Toast(ModeratorActivity.this);
+                    t.setText("Ending meeting did not succeed!");
+                    moderatorViewModel.endMeeting(t);
+                    finish();
+                    break;
 
-                        Intent i = new Intent(ModeratorActivity.this, RoleSelectionActivity.class);
-                        startActivity(i);
-                        //Yes button clicked
-                        break;
-
-                    case DialogInterface.BUTTON_NEGATIVE:
-                        //No button clicked
-                        break;
-                }
+                case DialogInterface.BUTTON_NEGATIVE:
+                    //No button clicked
+                    break;
             }
         };
         btn.setOnClickListener(view -> {

--- a/app/src/main/java/com/group7/meetr/viewmodel/ModeratorViewModel.java
+++ b/app/src/main/java/com/group7/meetr/viewmodel/ModeratorViewModel.java
@@ -1,20 +1,19 @@
 package com.group7.meetr.viewmodel;
 
-import android.app.Application;
 import android.util.Log;
+import android.widget.Toast;
 
 import androidx.databinding.BaseObservable;
+
+import com.group7.meetr.data.model.Meeting;
+import com.group7.meetr.data.remote.SessionHandler;
 
 public class ModeratorViewModel extends BaseObservable {
 
     public ModeratorViewModel(){
 
     }
-
-    public void onBtnNextClicked(){
-        Log.d("!TALKER", "Current talker should change!");
-        //TODO: Insert next participant here
-    }
+    
     public void onBtnParticipantsClicked(){
         Log.d("!ACTIVITY", "Change view to Participants!");
         //TODO: Swap view + activity here.
@@ -30,5 +29,9 @@ public class ModeratorViewModel extends BaseObservable {
     public void onBtnLeaveClicked(){
         Log.d("!ACTIVITY", "DEAD BUTTON...");
         //TODO: Add voting system and add that here? idk...
+    }
+
+    public void endMeeting(Toast toast) {
+        SessionHandler.callEndMeeting(Meeting.getMeetingID(), toast);
     }
 }


### PR DESCRIPTION
Changed code to kill activity rather than shift to another after ending a meeting. Also, moved code from activity to ViewModel in accordance with architecture.